### PR TITLE
Add conn.SERVICE_OPTS to all QueryService calls

### DIFF
--- a/pyslid/database/direct.py
+++ b/pyslid/database/direct.py
@@ -145,10 +145,10 @@ def deleteNameTag(conn, featureset, did=None):
 
     #for ExperimeterGroupANnotationLink objects
     query_string = "select grl from ExperimenterGroupAnnotationLink as grl join grl.child as ann where grl.parent.id = :gid and ann.ns=:namesp"
-    results_link = query.findAllByQuery(query_string, params)
+    results_link = query.findAllByQuery(query_string, params, conn.SERVICE_OPTS)
     #for tagAnnotation
     query_string = "select ann from ExperimenterGroupAnnotationLink as grl join grl.child as ann where grl.parent.id = :gid and ann.ns=:namesp"
-    results_tag = query.findAllByQuery(query_string, params)
+    results_tag = query.findAllByQuery(query_string, params, conn.SERVICE_OPTS)
 
     try:
         for result in results_link:
@@ -190,7 +190,8 @@ def getRecentName(conn, featureset, did=None):
 
     # get the most recent Tag
     query_string = "select ann from ExperimenterGroupAnnotationLink as grl join grl.child as ann where grl.parent.id = :gid and ann.ns=:namesp order by ann.id desc"
-    result = query.findByQuery(query_string, params.page(0,1))
+    result = query.findByQuery(
+        query_string, params.page(0,1), conn.SERVICE_OPTS)
 
     if result is None:
         DBName = None

--- a/pyslid/features.py
+++ b/pyslid/features.py
@@ -608,7 +608,7 @@ def hasTable( conn, iid, featureset="slf33", field=True, rid=None, debug=False )
     query = conn.getQueryService()
 	
     try:
-        result = query.findByQuery(string, params.page(0,1))
+        result = query.findByQuery(string, params.page(0,1), conn.SERVICE_OPTS)
     except:
 	result = None
 

--- a/pyslid/image.py
+++ b/pyslid/image.py
@@ -94,7 +94,7 @@ def getNomimalMagnification( conn, iid, debug=False ):
     query = conn.getQueryService()
 
     try:
-        result = query.findByQuery(string, params.page(0,1))
+        result = query.findByQuery(string, params.page(0,1), conn.SERVICE_OPTS)
     except:
         if debug:
             print "Unable to run query"
@@ -190,7 +190,8 @@ def getList( conn, debug=False ):
       me = conn.getAdminService().getEventContext().userId
       string = "select i.id from Image i where i.details.owner.id = :id"
       params = omero.sys.ParametersI().addId(me)
-      iids = omero.rtypes.unwrap(query.projection(string,params))
+      iids = omero.rtypes.unwrap(query.projection(
+              string, params, conn.SERVICE_OPTS))
       return iids 
    except:
       if debug:

--- a/pyslid/utilities.py
+++ b/pyslid/utilities.py
@@ -143,7 +143,7 @@ def getFileID( conn, iid, set, field=True ):
   
     try:
        #database query  
-       result = query.projection( string, params )
+       result = query.projection(string, params, conn.SERVICE_OPTS)
    
        #get answer
        fid = result.pop().pop()._val._child._file._id._val
@@ -269,7 +269,7 @@ def hasFile( conn, fid ):
     string = "select count(*) from OriginalFile f where f.id = :fid";
     
     #database query
-    result = query.projection( string, params )
+    result = query.projection(string, params, conn.SERVICE_OPTS)
     
     #get answer
     answer = result.pop().pop()._val
@@ -336,7 +336,7 @@ def hasPlane( conn, plid ):
     string = "select count(*) from Plane p where p.id = :plid";
     
     #database query
-    result = query.projection( string, params )
+    result = query.projection(string, params, conn.SERVICE_OPTS)
     
     #get answer
     answer = result.pop().pop()._val


### PR DESCRIPTION
Users can belong to multiple groups and switch between them. This PR should ensure their current group is taken into account.

Note `pyslid.table` and `pyslid.database.link` have not been updated as they don't seem to be used anywhere.
