### PR TITLE
Use unittest2 instead of unittest with Python 2.6

### DIFF
--- a/tests/ClientHelper.py
+++ b/tests/ClientHelper.py
@@ -22,7 +22,11 @@
 #
 #
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import omero
 from numpy import array, int8
 

--- a/tests/TestDatabaseDirect.py
+++ b/tests/TestDatabaseDirect.py
@@ -22,7 +22,11 @@
 #
 #
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import omero
 from omero.rtypes import unwrap, wrap
 from numpy import array

--- a/tests/TestFeatures.py
+++ b/tests/TestFeatures.py
@@ -22,7 +22,11 @@
 #
 #
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import omero
 from omero.rtypes import unwrap
 from numpy import array

--- a/tests/TestImage.py
+++ b/tests/TestImage.py
@@ -22,7 +22,11 @@
 #
 #
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 from ClientHelper import ClientHelper
 import omero
 


### PR DESCRIPTION
Make tests compatible with Python 2.6. Requires unittest2 module to be installed.
