### PR TITLE
Use a method set_contentdb_path() to set OMERO_CONTENTDB_PATH

### DIFF
--- a/pyslid/database/direct.py
+++ b/pyslid/database/direct.py
@@ -42,9 +42,23 @@ from os.path import exists, join
 import os
 
 NUM_DIGIT_COUNT = 20
-OMERO_CONTENTDB_PATH = os.environ['OMERO_CONTENTDB_PATH']
-if not OMERO_CONTENTDB_PATH.endswith(os.sep):
-    OMERO_CONTENTDB_PATH = OMERO_CONTENTDB_PATH + os.sep
+OMERO_CONTENTDB_PATH = None
+
+def set_contentdb_path(contentdb_path):
+    """
+    Set the OMERO_CONTENTDB_PATH, used to store the ContentDB files
+    """
+    global OMERO_CONTENTDB_PATH
+
+    #if contentdb_path is None:
+    #    contentdb_path = os.environ['OMERO_CONTENTDB_PATH']
+    if not contentdb_path.endswith(os.sep):
+        contentdb_path += os.sep
+    if not os.path.isdir(contentdb_path):
+        # TODO: Raise PyslidException
+        raise Exception('Invalid ContentDB directory: %s', contentdb_path)
+
+    OMERO_CONTENTDB_PATH = contentdb_path
 
 def search_file(filename, search_path):
    """Given a search path, find file

--- a/tests/TestDatabaseDirect.py
+++ b/tests/TestDatabaseDirect.py
@@ -52,9 +52,7 @@ class TestDatabaseDirect(ClientHelper):
         self.tempdir = tempfile.mkdtemp(prefix='omero_searcher_content_db-')
 
         # Override the OMERO.searcher contentdb path
-        os.environ['OMERO_CONTENTDB_PATH'] = self.tempdir + os.sep
-        pysliddb.OMERO_CONTENTDB_PATH = os.environ['OMERO_CONTENTDB_PATH']
-        #print 'OMERO_CONTENTDB_PATH changed to: %s' % self.tempdir
+        pysliddb.set_contentdb_path(self.tempdir)
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
@@ -163,6 +161,16 @@ class TestDatabaseDirect(ClientHelper):
 
         return iid, scale, px, ch, z, t, fids, feats, self.fake_ftset
 
+
+    def test_set_contentdb_path(self):
+        tempdir = tempfile.mkdtemp(prefix='omero_searcher_content_db-')
+        pysliddb.set_contentdb_path(tempdir)
+        self.assertEqual(pysliddb.OMERO_CONTENTDB_PATH,
+                         os.path.join(tempdir, ''))
+        os.rmdir(tempdir)
+
+        nonexistent = os.path.join(tempdir, 'non', 'existent')
+        self.assertRaises(Exception, pysliddb.set_contentdb_path, nonexistent)
 
     def test_initializeNameTag(self):
         g = self.conn.getObject('ExperimenterGroup', self.gid)


### PR DESCRIPTION
Require the ContentDB path to be explicitly set instead of relying on an environment variable.
