### PR TITLE
Set omero group 11449

### DIFF
--- a/pyslid/database/direct.py
+++ b/pyslid/database/direct.py
@@ -59,6 +59,21 @@ def set_contentdb_path(contentdb_path):
 
     OMERO_CONTENTDB_PATH = contentdb_path
 
+
+def getCurrentGroupId(conn):
+    '''
+    Returns the current group ID, either from SERVICE_OPTS if set or from the
+    current context.
+    @param connection (conn)
+    @return the current group ID
+    '''
+    gid = conn.SERVICE_OPTS.getOmeroGroup()
+    if gid is not None:
+        gid = long(gid)
+    else:
+        gid = conn.getEventContext().groupId
+    return gid
+
 def search_file(filename, search_path):
    """Given a search path, find file
    """
@@ -85,7 +100,7 @@ def initializeNameTag(conn, featureset, did=None):
     for i in range(NUM_DIGIT_COUNT-1):
         COUNT +="0"
     COUNT +="1"
-    gid = conn.getGroupFromContext().getId()
+    gid = getCurrentGroupId(conn)
     
     if did == None: 
         NameSpace = 'direct.edu.cmu.cs.compbio.omepslid:'+'all'+'_'+str(featureset)
@@ -141,9 +156,7 @@ def deleteNameTag(conn, featureset, did=None):
     @return Answer (True if successfully done)
     
     """
-    #get the name of the active group to which the user belongs
-    groupname = conn.getGroupFromContext().getName()
-    groupid = conn.getGroupFromContext().getId()
+    groupid = getCurrentGroupId(conn)
     
     #create query service
     query = conn.getQueryService()
@@ -186,9 +199,7 @@ def getRecentName(conn, featureset, did=None):
     @return tag (tagAnnotation)
     
     """
-    #get the name of the active group to which the user belongs
-    groupname = conn.getGroupFromContext().getName()
-    groupid = conn.getGroupFromContext().getId()
+    groupid = getCurrentGroupId(conn)
     
     #create query service
     query = conn.getQueryService()

--- a/pyslid/database/direct.py
+++ b/pyslid/database/direct.py
@@ -95,17 +95,20 @@ def initializeNameTag(conn, featureset, did=None):
         DBName = str(gid)+'_'+str(did)+'_'+str(featureset)+'_content_db_'+COUNT+'.pkl'
 
     #create an empty tag
-    tag = conn.getUpdateService().saveAndReturnObject(omero.model.TagAnnotationI())
+    tag = conn.getUpdateService().saveAndReturnObject(
+        omero.model.TagAnnotationI(), conn.SERVICE_OPTS)
     tag.setNs(omero.rtypes.RStringI(NameSpace))
     tag.setTextValue(omero.rtypes.RStringI(DBName))
-    tag=conn.getUpdateService().saveAndReturnObject(tag) # update the tag
+    tag = conn.getUpdateService().saveAndReturnObject(
+        tag, conn.SERVICE_OPTS) # update the tag
     
     flink = omero.model.ExperimenterGroupAnnotationLinkI()
     
 
     # link the tag to the ExperimentGroup
     flink.link(omero.model.ExperimenterGroupI(gid, False), tag)
-    conn.getUpdateService().saveObject(flink)   # update the link
+    conn.getUpdateService().saveObject(
+        flink, conn.SERVICE_OPTS)   # update the link
 
     return NameSpace, DBName
 
@@ -123,7 +126,7 @@ def updateNameTag(conn, tag, DBName_new):
     # change the DBName
     tag.setTextValue(omero.rtypes.RStringI(DBName_new))
     # update the tag
-    conn.getUpdateService().saveObject(tag)
+    conn.getUpdateService().saveObject(tag, conn.SERVICE_OPTS)
 
     return True
 
@@ -163,9 +166,9 @@ def deleteNameTag(conn, featureset, did=None):
 
     try:
         for result in results_link:
-            conn.getUpdateService().deleteObject(result)
+            conn.getUpdateService().deleteObject(result, conn.SERVICE_OPTS)
         for result in results_tag:
-            conn.getUpdateService().deleteObject(result)
+            conn.getUpdateService().deleteObject(result, conn.SERVICE_OPTS)
 
         return True
     except:

--- a/pyslid/features.py
+++ b/pyslid/features.py
@@ -541,8 +541,9 @@ def get( conn, option, iid, scale=None, set="slf33", field=True, rid=None, pixel
         #returns the file id associated with the table
         fid = result.getId().getValue()
         #open the table given the file id
-        table = conn.getSharedResources().openTable( omero.model.OriginalFileI( fid, False ) )
-                
+        table = conn.getSharedResources().openTable(
+            omero.model.OriginalFileI(fid, False), conn.SERVICE_OPTS)
+
         if option == 'table':
             return table
 
@@ -774,7 +775,8 @@ def link(conn, iid, scale, fids, features, set, field=True, rid=None, pixels=0, 
     if answer:
         fid = result.getId().getValue()
 
-        table = conn.getSharedResources().openTable( omero.model.OriginalFileI( fid, False ) )
+        table = conn.getSharedResources().openTable(
+            omero.model.OriginalFileI(fid, False), conn.SERVICE_OPTS)
 
         # append the new data
         columns[0].values.append( long(pixels) )
@@ -793,10 +795,14 @@ def link(conn, iid, scale, fids, features, set, field=True, rid=None, pixels=0, 
         # create a new table and link it to the image
         if field==True:
             #table for field features
-            table = conn.getSharedResources().newTable( 1, 'iid-' + str(iid) + '_feature-' + str(set) + '_field.h5' )
+            table = conn.getSharedResources().newTable(
+                1, 'iid-' + str(iid) + '_feature-' + str(set) + '_field.h5',
+                conn.SERVICE_OPTS)
         else:
             #table for cell level features (roi == regions of interest)
-            table = conn.getSharedResources().newTable( 1, 'iid-' + str(iid) + '_feature-' + str(set) + '_roi.h5' )
+            table = conn.getSharedResources().newTable(
+                1, 'iid-' + str(iid) + '_feature-' + str(set) + '_roi.h5',
+                conn.SERVICE_OPTS)
         table.initialize(columns)
 
         try:
@@ -808,7 +814,7 @@ def link(conn, iid, scale, fids, features, set, field=True, rid=None, pixels=0, 
             annotation.file = table.getOriginalFile()
             #create an annotation link between image and table
             flink.link( omero.model.ImageI(iid, False), annotation )
-            conn.getUpdateService().saveObject(flink)
+            conn.getUpdateService().saveObject(flink, conn.SERVICE_OPTS)
         except:
             table.close()
             raise PyslidException("Unable to create file annotation link")

--- a/tests/TestDatabaseDirect.py
+++ b/tests/TestDatabaseDirect.py
@@ -167,6 +167,13 @@ class TestDatabaseDirect(ClientHelper):
         return iid, scale, px, ch, z, t, fids, feats, self.fake_ftset
 
 
+    def test_getCurrentGroupId(self):
+        self.assertEqual(pysliddb.getCurrentGroupId(self.conn), self.gid)
+        # This group ID should never actually be used in an OMERO API call
+        newGid = sys.maxsize
+        self.conn.SERVICE_OPTS.setOmeroGroup(newGid)
+        self.assertEqual(pysliddb.getCurrentGroupId(self.conn), newGid)
+
     def test_set_contentdb_path(self):
         tempdir = tempfile.mkdtemp(prefix='omero_searcher_content_db-')
         pysliddb.set_contentdb_path(tempdir)


### PR DESCRIPTION
OMERO.web allows a user to change groups during a session. This PR ensures Pyslid uses this group. See https://trac.openmicroscopy.org.uk/ome/ticket/11449

To test: Switch between groups (includign default/non-default). OMERO.searcher should still work, and only return results from the current group.
